### PR TITLE
Fix parsing tests from manifest

### DIFF
--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -124,6 +124,9 @@ class Manifest:
                 continue
 
             depends_on = node['depends_on']['nodes']
+            if not depends_on:
+                continue
+
             if node['test_metadata']['name'] == 'relationships':
                 table_id = depends_on[len(depends_on) - 1]
             else:

--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -135,6 +135,9 @@ class Manifest:
             column_name = node['column_name'] or node['test_metadata']['kwargs']['column_name'] \
                 or node['test_metadata']['kwargs']['arg']
 
+            if not column_name:
+                continue
+
             table_tests = tests.setdefault(table_name, {})
             column_tests = table_tests.setdefault(column_name, [])
             column_tests.append(node)


### PR DESCRIPTION
# What was done

- Added forgotten conditions from the [official dbt-docs manifest parsing source code](https://github.com/dbt-labs/dbt-docs/blob/da84e95ab9febde3127ed28ff698516b2a610532/src/app/services/project_service.js#L199).
    - Fix parsing tests with no dependencies from manifest
    - Fix parsing tests with empty column name from manifest
