### PR TITLE
Fix matching of entities between manifest and catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.6] - 2021-12-03
 ### Fixed
 - Matching of entities between manifest and catalog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Matching of entities between manifest and catalog
 
 ## [0.1.5] - 2021-11-28
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ $ dbt-coverage compute doc --cov-report coverage-doc.json  # Compute doc coverag
 
 Coverage report
 =====================================================================
-customers                                              6/7      85.7%
-orders                                                 9/9     100.0%
-raw_customers                                          0/3       0.0%
-raw_orders                                             0/4       0.0%
-raw_payments                                           0/4       0.0%
-stg_customers                                          0/3       0.0%
-stg_orders                                             0/4       0.0%
-stg_payments                                           0/4       0.0%
+jaffle_shop.customers                                  6/7      85.7%
+jaffle_shop.orders                                     9/9     100.0%
+jaffle_shop.raw_customers                              0/3       0.0%
+jaffle_shop.raw_orders                                 0/4       0.0%
+jaffle_shop.raw_payments                               0/4       0.0%
+jaffle_shop.stg_customers                              0/3       0.0%
+jaffle_shop.stg_orders                                 0/4       0.0%
+jaffle_shop.stg_payments                               0/4       0.0%
 =====================================================================
 Total                                                 15/38     39.5%
 
@@ -53,14 +53,14 @@ $ dbt-coverage compute test --cov-report coverage-test.json  # Compute test cove
 
 Coverage report
 =====================================================================
-customers                                              1/7      14.3%
-orders                                                 8/9      88.9%
-raw_customers                                          0/3       0.0%
-raw_orders                                             0/4       0.0%
-raw_payments                                           0/4       0.0%
-stg_customers                                          1/3      33.3%
-stg_orders                                             2/4      50.0%
-stg_payments                                           2/4      50.0%
+jaffle_shop.customers                                  1/7      14.3%
+jaffle_shop.orders                                     8/9      88.9%
+jaffle_shop.raw_customers                              0/3       0.0%
+jaffle_shop.raw_orders                                 0/4       0.0%
+jaffle_shop.raw_payments                               0/4       0.0%
+jaffle_shop.stg_customers                              1/3      33.3%
+jaffle_shop.stg_orders                                 2/4      50.0%
+jaffle_shop.stg_payments                               2/4      50.0%
 =====================================================================
 Total                                                 14/38     36.8%
 ```
@@ -87,12 +87,12 @@ Misses            23        24          +1/+0
 =============================================
 
 # New misses
-==============================================================
-Catalog              15/38   (39.47%)  ->    15/39   (38.46%) 
-==============================================================
-- customers           6/7    (85.71%)  ->     6/8    (75.00%) 
--- new_col            -/-       (-)    ->     0/1     (0.00%) 
-==============================================================
+=========================================================================
+Catalog                         15/38   (39.47%)  ->    15/39   (38.46%) 
+=========================================================================
+- jaffle_shop.customers          6/7    (85.71%)  ->     6/8    (75.00%) 
+-- new_col                       -/-       (-)    ->     0/1     (0.00%) 
+=========================================================================
 ```
 
 ### Combined use-case

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dbt-coverage
 
-<a href="https://github.com/slidoapp/dbt-coverage/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/slidoapp/dbt-coverage"></a>
+<a href="https://github.com/slidoapp/dbt-coverage/blob/main/LICENSE.md"><img alt="License: MIT" src="https://img.shields.io/github/license/slidoapp/dbt-coverage"></a>
 <a href="https://pypi.org/project/dbt-coverage/"><img alt="PyPI" src="https://img.shields.io/pypi/v/dbt-coverage"></a>
 <a href="https://pepy.tech/project/dbt-coverage"><img alt="Downloads" src="https://pepy.tech/badge/dbt-coverage"></a>
 ![GitHub last commit](https://img.shields.io/github/last-commit/slidoapp/dbt-coverage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-coverage"
-version = "0.1.5"
+version = "0.1.6"
 description = "A package for computing coverage of dbt-managed data warehouses"
 authors = ["Andrej Švec <asvec@slido.com>"]
 readme = 'README.md'


### PR DESCRIPTION
This fixes two issues:

1. Some systems (e.g. Snowflake) uppercase all table and column names. In accordance with the dbt-docs official source code, we lowercase all table and column names before matching them.
2. There can be multiple tables with the same name but in different schemas. We therefore use schema_name.table_name to distinguish tables.