### PR TITLE
Fix manifest parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- `manifest.json` parsing.
 
 ## [0.1.7] - 2021-12-09
 ### Changed

--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -119,8 +119,9 @@ class Manifest:
             else:
                 table_id = depends_on[0]
             table_name = id_to_table_name[table_id]
-            column_name = node['column_name'] or node['test_metadata']['kwargs']['column_name'] \
-                or node['test_metadata']['kwargs']['arg']
+            column_name = node.get('column_name') \
+                or node['test_metadata']['kwargs'].get('column_name') \
+                or node['test_metadata']['kwargs'].get('arg')
 
             if not column_name:
                 continue


### PR DESCRIPTION
Sometimes `column_name` can be missing which was resulting in `KeyError`s. In the original `dbt-docs` Javascript code, the language itself was taking care of this, whereas in Python we had to do it manually.

https://github.com/dbt-labs/dbt-docs/blob/13bc6bda002aafc69bc99b0071a77037943fe369/src/app/services/project_service.js#L204

Hopefully fixes #16.