### PR TITLE
dbt 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for `dbt==1.0.*`
+
+### Removed
+- Support for `dbt<1`
 
 ## [0.1.10] - 2022-03-03
 ### Changed

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 ![GitHub last commit](https://img.shields.io/github/last-commit/slidoapp/dbt-coverage)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dbt-coverage)
 ![PyPI - Format](https://img.shields.io/pypi/format/dbt-coverage)
+![dbt versions](https://img.shields.io/badge/dbt-1.0-blue)
 <a href="https://github.com/slidoapp/dbt-coverage/blob/main/LICENSE.md"><img alt="License: MIT" src="https://img.shields.io/github/license/slidoapp/dbt-coverage"></a>
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fslidoapp%2Fdbt-coverage.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fslidoapp%2Fdbt-coverage?ref=badge_shield)
 
 
 _One-stop-shop for docs and test coverage of [`dbt`](https://github.com/dbt-labs/dbt) projects._
+
+Optimized for dbt 1.0, see [full support matrix](#supported-dbt-versions).
 
 ## Why do I need something like this?
 
@@ -141,6 +144,17 @@ $ dbt docs generate  # Generate catalog.json and manifest.json
 $ dbt-coverage compute doc --cov-report after.json --cov-fail-compare before.json  # Fail if the current coverage is lower than coverage in before.json
 $ dbt-coverage compare after.json before.json  # Generate a detailed coverage delta report
 ```
+
+## Supported `dbt` versions
+
+Different version of `dbt-coverage` support different versions of `dbt`. Here is
+the support matrix.
+
+| `dbt`       | `dbt-coverage` |
+|-------------|----------------|
+| <0.20       | not tested     |
+| 0.20 - 0.21 | 0.1            |
+| 1.0         | 0.2            |
 
 ## Related packages
 


### PR DESCRIPTION
- Support dbt 1.0 and drop support for dbt<1
- Warn when using with unsupported manifest.json version

@mrshu, I acknowledged the changes in the new v4 `manifest.json` format introduced by dbt 1.0 and by that the support for v3 dropped. Since the difference between the formats is only tiny, do you think it would make sense to support also v3 `manifest.json` (used in dbt<1) by having 2 methods for parsing the manifest, one for v3 and one for v4?

Closes #26.