### PR TITLE
Fix case when table.original_file_path is None

### DIFF
--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -125,6 +125,8 @@ class Catalog:
 
         original_tables_dict = {key: val for key, val in self.tables.items()}
         for key, table in original_tables_dict.items():
+            if table.original_file_path is None:
+                continue
             for path in model_path_filter:
                 if table.original_file_path.startswith(path):
                     filtered_tables[key] = table


### PR DESCRIPTION
Hello, first thanks for the package I think this can be very useful as more and more dbt projects become matures. 
There was a bug because table.original_file_path is sometimes equal to None and None.startswith does not work. 
So I just added a continue if clause if the table.original_file_path is equal to None. 

Error Log: 

```
  File "/Users/user/Library/Caches/pypoetry/virtualenvs/venv/lib/python3.8/site-packages/dbt_coverage/__init__.py", line 132, in filter_catalog
    if table.original_file_path.startswith(path):
AttributeError: 'NoneType' object has no attribute 'startswith'
```

The fix is tested successfully locally :) 

