### PR TITLE
Using unique_id for manifest and catalog nodes to allow for aliased m…

### DIFF
--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -147,7 +147,7 @@ class Catalog:
     @staticmethod
     def from_nodes(nodes):
         tables = [Table.from_node(table) for table in nodes]
-        return Catalog({table.name: table for table in tables})
+        return Catalog({table.unique_id.lower(): table for table in tables})
 
     def get_table(self, table_name):
         return self.tables.get(table_name)
@@ -273,7 +273,7 @@ class Manifest:
 
     @staticmethod
     def _full_table_name(table):
-        return f'{table["schema"]}.{table["name"]}'.lower()
+        return f"{table['unique_id']}".lower()
 
     @staticmethod
     def _normalize_column_names(columns):


### PR DESCRIPTION
Resolves #30  
Potentially resolves #40 

# What has changed?
Updates to the `load_manifest` and `load_catalog` functions to use the `unique_id` of the dbt model or test, instead of a schema + aliased name of the object.

The Coverage Report still returns the aliased object name, but the documentation coverage will be correctly calculated for each table as the manifest and catalog now use the normalized `unique_id`

Tested this for both `doc` and `test` cov_type and working as expected.
