### PR TITLE
fix: protect division by zero

### DIFF
--- a/dbt_coverage/__init__.py
+++ b/dbt_coverage/__init__.py
@@ -324,7 +324,7 @@ class CoverageReport:
     subentities: Dict[str, CoverageReport]
 
     def __post_init__(self):
-        if self.covered is not None and self.total is not None:
+        if self.covered is not None and self.total is not None and self.total != 0 :
             self.misses = self.total - self.covered
             self.coverage = len(self.covered) / len(self.total)
         else:


### PR DESCRIPTION
To reproduce division by zero error: 

```bash
dbt init 
cd dbt_generated_project
dbt docs generate
dbt-coverage compute doc
```
This error occurs on empty project.