### PR TITLE
Markdown capability for coverage comparison reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for markdown output format. [#90] _Thanks to @vvvito!_
+
+### Changed
+- The output format argument from cov_format to output_format. [#90]
 
 ## [0.4.0] - 2025-10-20
 ### Added


### PR DESCRIPTION
Resolves #88 

Added the ability to convert the string formatted comparison report into a markdown compliant format.
Useful for CI/CD pipelines and fills out the feature, as `compute` command has markdown capability, but `compare` didn't.

## Main changes:
- Updated the `CoverageFormat` enum name to just 'Format' and reused it across the `compare` / `compute` functions.
- Added a property to the `CoverageDiff` dataclass that holds the passed in `Format`, defaults to `Format.STRING_TABLE` instead of `Format.MARKDOWN_TABLE`
- Updated styling on the output to include box ASCII, to better highlight the heirarchy between tables and their relative columns

The `string` version of the report inherits the new styling of the box ASCII characters, but remains relatively unchanged, e.g.:

```
              before     after            +/-
=============================================
Coverage      34.97%    32.87%         -2.10%
=============================================
Tables            13        13          +0/+0
Columns          286       286          +0/+0
=============================================
Hits             100        94          +0/-6
Misses           186       192          +6/+0
=============================================

==============================================================================================
Catalog                                             100/286  (34.97%)  ->    94/286  (32.87%)
==============================================================================================
┌ `dim.dim_core_patients`                            25/39   (64.10%)  ->    22/39   (56.41%)
├── `family_name_preferred`                           1/1    (100.00%) ->     0/1     (0.00%)
├── `date_of_birth_estimation_flag`                   1/1    (100.00%) ->     0/1     (0.00%)
└── `mrn`                                             1/1    (100.00%) ->     0/1     (0.00%)
==============================================================================================
┌ `dim.dim_core_patient_current_identifiers`          8/11   (72.73%)  ->     6/11   (54.55%)
├── `person_id`                                       1/1    (100.00%) ->     0/1     (0.00%)
└── `tac number`                                      1/1    (100.00%) ->     0/1     (0.00%)
==============================================================================================
┌ `dim.dim_core_orders`                              21/22   (95.45%)  ->    20/22   (90.91%)
└── `name_cvid`                                       1/1    (100.00%) ->     0/1     (0.00%)
==============================================================================================
```

## How to invoke
We can now use a new option with the `compare` command called ``--compare-format`
```
dbt_coverage compare --compare-format markdown coverage.json old_coverage.json
```

Which will output the following:

```md
|           |   before      |      after      |  +/- |
|:----------|:-------------:|:---------------:|:----:|
| Coverage  |     34.97% |     32.87% |     -2.10% |
| Tables    |         13    |         13    | +0/+0    |
| Columns   |        286   |        286   | +0/+0   |
| Hits      |        100      |         94      | +0/-6      |
| Misses    |        186    |        192    | +6/+0    |

|     | before (%) | after (%) |
|:----|:----------:|:--------:|
| Catalog | 100/286 (34.97%) | 94/286 (32.87%) |
| ┌ `dim.dim_core_patient_current_identifiers` | 8/11 (72.73%) | 6/11 (54.55%) |
| ├── `person_id` | 1/1 (100.00%) | 0/1 (0.00%) |
| └── `tac number` | 1/1 (100.00%) | 0/1 (0.00%) |
| ┌ `dim.dim_core_orders` | 21/22 (95.45%) | 20/22 (90.91%) |
| └── `name_cvid` | 1/1 (100.00%) | 0/1 (0.00%) |
| ┌ `dim.dim_core_patients` | 25/39 (64.10%) | 22/39 (56.41%) |
| ├── `date_of_birth_estimation_flag` | 1/1 (100.00%) | 0/1 (0.00%) |
| ├── `family_name_preferred` | 1/1 (100.00%) | 0/1 (0.00%) |
| └── `mrn` | 1/1 (100.00%) | 0/1 (0.00%) |
```

When converted into a markdown compliant editor:

|           |   before      |      after      |  +/- |
|:----------|:-------------:|:---------------:|:----:|
| Coverage  |     34.97% |     32.87% |     -2.10% |
| Tables    |         13    |         13    | +0/+0    |
| Columns   |        286   |        286   | +0/+0   |
| Hits      |        100      |         94      | +0/-6      |
| Misses    |        186    |        192    | +6/+0    |

|     | before (%) | after (%) |
|:----|:----------:|:--------:|
| Catalog | 100/286 (34.97%) | 94/286 (32.87%) |
| ┌ `dim.dim_core_patient_current_identifiers` | 8/11 (72.73%) | 6/11 (54.55%) |
| ├── `person_id` | 1/1 (100.00%) | 0/1 (0.00%) |
| └── `tac number` | 1/1 (100.00%) | 0/1 (0.00%) |
| ┌ `dim.dim_core_orders` | 21/22 (95.45%) | 20/22 (90.91%) |
| └── `name_cvid` | 1/1 (100.00%) | 0/1 (0.00%) |
| ┌ `dim.dim_core_patients` | 25/39 (64.10%) | 22/39 (56.41%) |
| ├── `date_of_birth_estimation_flag` | 1/1 (100.00%) | 0/1 (0.00%) |
| ├── `family_name_preferred` | 1/1 (100.00%) | 0/1 (0.00%) |
| └── `mrn` | 1/1 (100.00%) | 0/1 (0.00%) |


